### PR TITLE
Ability to load library into browser without browserify

### DIFF
--- a/metar.js
+++ b/metar.js
@@ -1,6 +1,9 @@
 (function() {
 
-var parseRVR = require("./rvr");
+    if(typeof require !== 'undefined') {
+        var parseRVR = require("./rvr");
+    }
+
 // http://www.met.tamu.edu/class/metar/metar-pg10-sky.html
 // https://ww8.fltplan.com/AreaForecast/abbreviations.htm
 // http://en.wikipedia.org/wiki/METAR


### PR DESCRIPTION
When I try to load library, browser throws an error: 

`metar.js:4 Uncaught ReferenceError: require is not defined`

This conditional statement was the only thing needed to remove browserify as a depenedeny.
