### PR TITLE
Add support for visibility with a fraction (eg. 2 1/2SM)

### DIFF
--- a/metar.js
+++ b/metar.js
@@ -297,6 +297,27 @@
         }
     };
 
+    METAR.prototype.parseVisibilityFraction = function() {
+        var re = /^([0-9]+)\/([0-9]+)([A-Z]{1,2})/g;
+
+        if (this.result.cavok) return;
+        if (this.current === "////") return;
+
+        if (this.peek().match(re)) {
+            this.next();
+            var matches;
+            while ((matches = re.exec(this.current)) != null) {
+                if (matches.index === re.lastIndex) {
+                    re.lastIndex++;
+                }
+
+                var numerator = asInt(matches[1]);
+                var denominator = asInt(matches[2]);
+                this.result.visibility += (numerator / denominator);
+            }
+        }
+    };
+
     METAR.prototype.parseRunwayVisibility = function() {
         if (this.result.cavok) return;
         if (this.peek().match(/^R[0-9]+/)) {
@@ -397,6 +418,7 @@
         this.parseWind();
         this.parseCavok();
         this.parseVisibility();
+        this.parseVisibilityFraction();
         this.parseRunwayVisibility();
         this.parseWeather();
         this.parseClouds();

--- a/test/metar.test.js
+++ b/test/metar.test.js
@@ -149,6 +149,13 @@ describe("METAR parser", function() {
             assert.equal("NW", m.visibilityVariationDirection);
         });
 
+        it("can parse visibility with a fraction (2 1/2SM)", function () {
+            var m = parseMetar(
+                "KPWT 141733Z AUTO 24006KT 2 1/2SM -RA BR BKN005 OVC015 08/07 A3020 RMK AO2 CIG 004V008 P0001"
+            );
+            assert.equal(2.5, m.visibility);
+        });
+
         it("can parse clouds with a direction thing?", () => {
             var m = parseMetar(
                 "EFJY 201120Z 30001KT 9999 1500NW -SN SCT002 BKN007 M17/M18 Q1031"


### PR DESCRIPTION
Test describes the situation. sometimes visibility comes in 2 parts, for example: `2 1/2SM`.
In that case the decoder would fail to parse the rest of the Metar.

This fix corrects the visibility (visibility used to be `2` and will now be `2.5` when parsed) and the rest of the Metar is properly decoded.